### PR TITLE
Bootstrap 4 template + tiny test fix

### DIFF
--- a/docs/start.rst
+++ b/docs/start.rst
@@ -126,6 +126,7 @@ Then open ``config/breadcrumbs.php`` and edit this line:
 
 The possible values are:
 
+- `Bootstrap 4 <https://v4-alpha.getbootstrap.com/components/breadcrumb/>`_: ``breadcrumbs::bootstrap4``
 - `Bootstrap 3 <http://getbootstrap.com/components/#breadcrumbs>`_: ``breadcrumbs::bootstrap3``
 - `Bootstrap 2 <http://getbootstrap.com/2.3.2/components.html#breadcrumbs>`_: ``breadcrumbs::bootstrap2``
 - The path to a custom view: e.g. ``_partials/breadcrumbs``

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -31,6 +31,7 @@ class IntegrationTest extends TestCase
     }
 
     public function testGenerate()
+    {
         $breadcrumbs = Breadcrumbs::generate('post', $this->post);
 
         $this->assertCount(3, $breadcrumbs);

--- a/views/bootstrap4.blade.php
+++ b/views/bootstrap4.blade.php
@@ -1,0 +1,19 @@
+<nav class="breadcrumb">
+    @foreach ($breadcrumbs as $breadcrumb)
+        @if (!$breadcrumb->last)
+            <a class="breadcrumb-item" href="{{ $breadcrumb->url }}">
+                @if ( isset($breadcrumb->icon) )
+                    <i class="fa {{ $breadcrumb->icon }}"></i>
+                @endif
+                {{ $breadcrumb->title }}
+            </a>
+        @else
+            <span class="breadcrumb-item active">
+                @if ( isset($breadcrumb->icon) )
+                    <i class="fa {{ $breadcrumb->icon }}"></i>
+                @endif
+                {{ $breadcrumb->title }}
+            </span>
+        @endif
+    @endforeach
+</nav>


### PR DESCRIPTION
I've added the BS4 template according to a [request](https://github.com/davejamesmiller/laravel-breadcrumbs/issues/128) in the original repo. There was also a parse error in one of the test cases.